### PR TITLE
Assign end date on day selection

### DIFF
--- a/src/screens/Book.tsx
+++ b/src/screens/Book.tsx
@@ -332,7 +332,10 @@ export default function Book({route, navigation}: any) {
       return;
     }
 
-    setStartDate(moment(formattedDate).format('YYYY-MM-DD'));
+    const date = moment(formattedDate).format('YYYY-MM-DD');
+
+    setStartDate(date);
+    setEndDate(date);
 
     markedDatesCopy[moment(day.dateString).format('YYYY-MM-DD')] = {
       customStyles: {


### PR DESCRIPTION
## Summary
- Set end date to match start date when a day is selected

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run lint` *(fails: 736 problems, 111 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6896325d46808325873382783df485e8