### PR TITLE
fix: display quota photo on booking screen

### DIFF
--- a/src/screens/Book.tsx
+++ b/src/screens/Book.tsx
@@ -386,15 +386,11 @@ export default function Book({route, navigation}: any) {
     return <Loading />;
   }
 
-  console.log({quota});
-
-  console.log({condicao: quota?.Photos.lenght > 0});
-
   return (
     <SafeAreaView style={{backgroundColor: '#fff', flex: 1}}>
       <ScrollView ref={scrollViewRef}>
         <View style={{flex: 1}}>
-          {quota?.Photos.lenght > 0 ? (
+          {quota?.Photos.length > 0 ? (
             <FlatList
               horizontal
               data={quota?.Photos}


### PR DESCRIPTION
## Summary
- show quota photos on booking screen when available

## Testing
- `npm test` (fails: SyntaxError in Jest configuration)


------
https://chatgpt.com/codex/tasks/task_e_689697dc7c8883258f6ce2868f5d3f0e